### PR TITLE
Implement function to accept flat array when building grid

### DIFF
--- a/src/hex/game/game.go
+++ b/src/hex/game/game.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Game struct {
-	Matrix [][]int
+	Array []int
 	Player int
 }
 
@@ -15,7 +15,7 @@ type Game struct {
 // This function determines if a game is won based on a game
 func IsWinningGame(game Game) bool {
 
-	Grid := grid.GetGridFromMatrix(game.Matrix)
+	Grid := grid.GetGridFromArray(game.Array)
 
 	endVertexId := graph.GetEndVertexId(Grid.Width)
 	Graph := graph.BuildGraphForPlayer(Grid, game.Player)

--- a/src/hex/grid/grid.go
+++ b/src/hex/grid/grid.go
@@ -2,6 +2,7 @@ package grid
 
 import (
 	"errors"
+	"math"
 )
 
 const Empty = 0
@@ -23,6 +24,34 @@ func NewGrid(stones []Stone, width int) *Grid {
 
 func getDirections() [6][2]int {
 	return [6][2]int{{0, -1}, {1, -1}, {1, 0}, {-1, 0}, {-1, 1}, {0, 1}}
+}
+
+func GetGridFromArray(array []int) Grid {
+
+	length := len(array)
+	width := int(math.Sqrt(float64(length)))
+
+	stones := make([]Stone, length)
+	stones = stones[:0]
+
+	grid := NewGrid(stones, width)
+
+	y := 0
+	x := 0
+	count := 0
+	for value := range array {
+		if x == width - 1 {
+			x = 0
+			y++
+		} else {
+			x++
+		}
+
+		player := getPlayerValue(value)
+		grid.Stones = append(grid.Stones, *NewStone(count, x, y, player))
+	}
+
+	return *grid
 }
 
 func GetGridFromMatrix(matrix [][]int) Grid {

--- a/src/hex/grid/grid_test.go
+++ b/src/hex/grid/grid_test.go
@@ -98,9 +98,33 @@ func TestUserCantGetAStoneWithWrongCoords(t *testing.T) {
 		{1, 1, 1, 0, 2},
 		{1, 0, 0, 0, 2},
 	}
-	stones := GetGridFromMatrix(matrix)
+	Grid := GetGridFromMatrix(matrix)
 
-	got, err := loadStoneByCoord(stones, -1, -1)
+	got, err := loadStoneByCoord(Grid, -1, -1)
+
+	expected := Stone{}
+
+	if got != expected {
+		t.Errorf("got %v; want %v", got, expected)
+	}
+
+	if err == nil {
+		t.Errorf("got %v; want not nil", err)
+	}
+}
+
+func TestUserCanGetAGridBasedOnAnArray(t *testing.T){
+	array := []int{
+		0, 1, 1, 0, 2,
+		0, 1, 2, 2, 2,
+		0, 1, 0, 0, 2,
+		1, 1, 1, 0, 2,
+		1, 0, 0, 0, 2,
+	}
+
+	Grid := GetGridFromArray(array)
+
+	got, err := loadStoneByCoord(Grid, -1, -1)
 
 	expected := Stone{}
 


### PR DESCRIPTION
## Description

In this PR, I have changed the type of input to build the grid object.

### Matrix format (old)
```
	matrix := [][]int{
		{0, 1, 1, 0, 2},
		{0, 1, 2, 2, 2},
		{0, 1, 0, 0, 2},
		{1, 1, 1, 0, 2},
		{1, 0, 0, 0, 2},
	}
```
### Array format (new)
```
	array := []int{
		0, 1, 1, 0, 2,
		0, 1, 2, 2, 2,
		0, 1, 0, 0, 2,
		1, 1, 1, 0, 2,
		1, 0, 0, 0, 2,
	}
```

Trello : [https://trello.com/c/zqtlVJDr/6-1-as-norbert-i-want-to-know-when-any-of-the-players-have-won](url)
