### PR TITLE
Add Allow Origin and pre-flight options to bypass CORS

### DIFF
--- a/src/api/handler/handler.go
+++ b/src/api/handler/handler.go
@@ -18,18 +18,12 @@ func IsWonHandler(responseWriter http.ResponseWriter, request *http.Request) {
 	currentGame := getGameByRequest(request)
 	response := fmt.Sprintf(`{"isWon": %t}`, game.IsWinningGame(currentGame))
 
-	prepareHeaders(&responseWriter)
 	responseWriter.WriteHeader(http.StatusOK)
-
 	io.WriteString(responseWriter, response)
 }
 
-func prepareHeaders(writer *http.ResponseWriter) {
-	(*writer).Header().Set("Content-Type", "application/json")
-	(*writer).Header().Set("Access-Control-Allow-Origin", "*")
-}
-
 func setupResponse(writer *http.ResponseWriter) {
+	(*writer).Header().Set("Content-Type", "application/json")
 	(*writer).Header().Set("Access-Control-Allow-Origin", "*")
 	(*writer).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	(*writer).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")

--- a/src/api/handler/handler.go
+++ b/src/api/handler/handler.go
@@ -9,13 +9,30 @@ import (
 )
 
 func IsWonHandler(responseWriter http.ResponseWriter, request *http.Request) {
-	currentGame := getGameByRequest(request)
 
+	setupResponse(&responseWriter)
+	if (*request).Method == "OPTIONS" {
+		return
+	}
+
+	currentGame := getGameByRequest(request)
 	response := fmt.Sprintf(`{"isWon": %t}`, game.IsWinningGame(currentGame))
 
+	prepareHeaders(&responseWriter)
 	responseWriter.WriteHeader(http.StatusOK)
-	responseWriter.Header().Set("Content-Type", "application/json")
+
 	io.WriteString(responseWriter, response)
+}
+
+func prepareHeaders(writer *http.ResponseWriter) {
+	(*writer).Header().Set("Content-Type", "application/json")
+	(*writer).Header().Set("Access-Control-Allow-Origin", "*")
+}
+
+func setupResponse(writer *http.ResponseWriter) {
+	(*writer).Header().Set("Access-Control-Allow-Origin", "*")
+	(*writer).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	(*writer).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }
 
 func getGameByRequest(request *http.Request) game.Game {


### PR DESCRIPTION
## Description

I add some headers on the request to allow all origins and pre-flight options. It's just for the POC, it's not a real production configuration. 

Trello : [https://trello.com/c/zqtlVJDr/6-1-as-norbert-i-want-to-know-when-any-of-the-players-have-won](url)
